### PR TITLE
Change 'none' to 'null' to avoid jekyll build error

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -1,5 +1,5 @@
 ---
-layout: none
+layout: null
 ---
 
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
As title. I'm not sure if this is new behavior, but it was easy to fix.

my reference: https://github.com/jekyll/jekyll/issues/2712

Thumbs up for such a clean theme, currently working on getting my own blog with a version of this theme up and running.
